### PR TITLE
Updated sdk to prerelease version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ guest = []
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1"
-wasmflow-sdk = { version = "0.10", features = ["v1"] }
+wasmflow-sdk = { version = "0.10.0-beta.4", features = ["v1"] }
 
 [dev-dependencies]


### PR DESCRIPTION
The first release of the SDK is `0.10.0-beta.4` until it gets beat on a little bit.